### PR TITLE
Remove duplicated h() calls

### DIFF
--- a/app/View/Organisations/ajax/sg_org_row_empty.ctp
+++ b/app/View/Organisations/ajax/sg_org_row_empty.ctp
@@ -9,7 +9,7 @@
 ?>
 	<td id="orgExtend<?php echo $id;?>"><input id="orgExtendInput<?php echo $id;?>" type="checkbox" onClick="sharingGroupExtendOrg(<?php echo $id;?>)" <?php echo h($checked);?>></input></td>
 <?php else: ?>
-	<td id="orgExtend<?php echo h($id);?>" ><span  id="orgExtendSpan<?php echo h($id);?>" class="icon-ok"></span></td>
+	<td id="orgExtend<?php echo $id;?>" ><span  id="orgExtendSpan<?php echo $id;?>" class="icon-ok"></span></td>
 <?php endif; ?>
-	<td id="orgAction<?php echo h($id);?>" class="actions short"></td>
+	<td id="orgAction<?php echo $id;?>" class="actions short"></td>
 </tr>


### PR DESCRIPTION
Just removing some duplicated h() calls as the first line is already calling it.

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch
